### PR TITLE
Correcting resource name to be MPI and not GPU

### DIFF
--- a/services/sleeper/docker-compose-meta.yml
+++ b/services/sleeper/docker-compose-meta.yml
@@ -104,5 +104,5 @@ services:
         simcore.service.settings: '[{ "name": "constraints", "type": "string", "value":
           ["node.platform.os == linux"]},{"name": "Resources", "type": "Resources",
           "value": { "Reservations": { "GenericResources": [{"DiscreteResourceSpec":
-          { "Kind": "VRAM", "Value": 1}}]}}}]'
+          { "Kind": "MPI", "Value": 1}}]}}}]'
 version: '3.7'


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The MPI service was tagged using the GPU resource. This corrects it. Will overwrite old images.

## Related issue number

<!-- Please add #issues -->


## Checklist

- [ ] I think the code is well written
- [ ] I updated the table of contents (make toc)
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS
