### PR TITLE
Fix VTK dispatcher p2e test - don't expect settings file in default bootmode

### DIFF
--- a/services/3d-viewer-gpu/docker/custom/entrypoint.bash
+++ b/services/3d-viewer-gpu/docker/custom/entrypoint.bash
@@ -66,9 +66,7 @@ if [ "${DY_BOOT_OPTION_BOOT_MODE}" -eq "0" ]; then
     set +e
     echo
     echo "setting input folder as data folder --> --data PARAVIEW_INPUT_PATH: ${PARAVIEW_INPUT_PATH}"
-    echo "INFO: In the dy-sidecars inputs might be pulled after the entrypoint.sh is executed. Inputs might not be present when the binary of paraview is executed."
     visualizer_options+=(--data "${PARAVIEW_INPUT_PATH}")
-    visualizer_options+=(--load-file "${SIMCORE_STATE_FILE}")
 elif [ "${DY_BOOT_OPTION_BOOT_MODE}" -eq "1" ] && [ -f /data_baked/3Danatomical/"${SIMCORE_STATE_FILE}" ]; then
     set -e
     export PARAVIEW_INPUT_PATH=/data_baked/3Danatomical/
@@ -100,7 +98,6 @@ else
     export PARAVIEW_INPUT_PATH=/data/A
     set +e
     visualizer_options+=(--data "${PARAVIEW_INPUT_PATH}")
-    visualizer_options+=(--load-file "${SIMCORE_STATE_FILE}")
 fi
 
 # start server


### PR DESCRIPTION
Fix VTK dispatcher p2e test - don't expect settings file in default bootmode


This should be again published (read: overwrite existing image) as `3.0.5`
